### PR TITLE
Migrate from PodIdentity to WorkloadIdentity

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"features": {
+		"ghcr.io/devcontainers/features/azure-cli:1": {
+			"installBicep": true,
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+			"version": "latest",
+			"helm": "latest",
+			"minikube": "none"
+		}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/Bicep/deploy-scaledobject.yaml
+++ b/Bicep/deploy-scaledobject.yaml
@@ -13,10 +13,10 @@ spec:
     - type: external
       metadata:
         scalerAddress: cosmosdb-scaler.cosmosdb-order-processor:4050
-        endpoint: https://{Cosmos Account Name}.documents.azure.com:443/ # update as per your environment
+        endpoint: https://{Cosmos DB Account Name}.documents.azure.com:443/ # update as per your environment
         databaseId: StoreDatabase
         containerId: OrderContainer
-        LeaseEndpoint: https://{Cosmos Account Name}.documents.azure.com:443/ # update as per your environment
+        LeaseEndpoint: https://{Cosmos DB Account Name}.documents.azure.com:443/ # update as per your environment
         leaseDatabaseId: StoreDatabase
         leaseContainerId: OrderProcessorLeases
         processorName: OrderProcessor

--- a/Bicep/modules/Identity/federatedcredential.bicep
+++ b/Bicep/modules/Identity/federatedcredential.bicep
@@ -1,0 +1,20 @@
+param aksCluster_issuerUrl string
+param identity_name string
+param service_account_namespace string 
+param service_account_name string
+
+resource azidentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2022-01-31-preview' existing = {
+  name: identity_name
+}
+
+resource federatedCredential 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2023-01-31' = {
+  name: 'string'
+  parent: azidentity
+  properties: {
+    audiences: [
+      'api://AzureADTokenExchange'
+    ]
+    issuer: aksCluster_issuerUrl
+    subject: 'system:serviceaccount:${service_account_namespace}:${service_account_name}'
+  }
+}

--- a/Bicep/modules/Identity/userassigned.bicep
+++ b/Bicep/modules/Identity/userassigned.bicep
@@ -8,4 +8,5 @@ resource azidentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2022-01-31
 output identityid string = azidentity.id
 output clientId string = azidentity.properties.clientId
 output principalId string = azidentity.properties.principalId
+output name string = azidentity.name
 

--- a/Bicep/modules/acr/acr.bicep
+++ b/Bicep/modules/acr/acr.bicep
@@ -24,7 +24,7 @@ resource acrPullDefinition 'Microsoft.Authorization/roleDefinitions@2018-01-01-p
 
 
 resource aksAcrPermissions 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
-  name: guid(resourceGroup().id)
+  name: guid(principalId, resourceGroup().id, acrPullDefinition.id)
   scope: acr
   properties: {
     principalId: principalId

--- a/Bicep/ordergenerator_mp_deploy.yaml
+++ b/Bicep/ordergenerator_mp_deploy.yaml
@@ -4,7 +4,6 @@ metadata:
   name: multi-partition-order-generator
   namespace: cosmosdb-order-processor  
   labels:
-    aadpodidbinding: "cosmosdb-order-processor-identity"
     app: multi-partition-order-generator
 spec:
   replicas: 1
@@ -15,8 +14,9 @@ spec:
     metadata:
       labels:
         app: multi-partition-order-generator
-        aadpodidbinding: "cosmosdb-order-processor-identity"
+        azure.workload.identity/use: "true"
     spec:
+      serviceAccountName: workload-identity-sa
       containers:
       - name: mycontainer
         image: {ACR Name}.azurecr.io/cosmosdb/order-generator:latest   # update as per your environment, example myacrname.azurecr.io/cosmosdb/order-generator:latest. Do NOT add https:// in ACR Name

--- a/Bicep/ordergenerator_sp_deploy.yaml
+++ b/Bicep/ordergenerator_sp_deploy.yaml
@@ -4,7 +4,6 @@ metadata:
   name: single-partition-order-generator
   namespace: cosmosdb-order-processor  
   labels:
-    aadpodidbinding: "cosmosdb-order-processor-identity"
     app: single-partition-order-generator
 spec:
   replicas: 1
@@ -15,8 +14,9 @@ spec:
     metadata:
       labels:
         app: single-partition-order-generator
-        aadpodidbinding: "cosmosdb-order-processor-identity"
+        azure.workload.identity/use: "true"
     spec:
+      serviceAccountName: workload-identity-sa
       containers:
       - name: mycontainer
         image: {ACR Name}.azurecr.io/cosmosdb/order-generator:latest   # update as per your environment, example myacrname.azurecr.io/cosmosdb/order-generator:latest. Do NOT add https:// in ACR Name

--- a/Bicep/orderprocessor_deploy.yaml
+++ b/Bicep/orderprocessor_deploy.yaml
@@ -2,8 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cosmosdb-order-processor
+  namespace: cosmosdb-order-processor
   labels:
-    aadpodidbinding: "cosmosdb-order-processor-identity"
     app: cosmosdb-order-processor
 spec:
   replicas: 1
@@ -14,8 +14,9 @@ spec:
     metadata:
       labels:
         app: cosmosdb-order-processor
-        aadpodidbinding: "cosmosdb-order-processor-identity"
+        azure.workload.identity/use: "true"
     spec:
+      serviceAccountName: sa
       containers:
       - name: mycontainer
         image: {ACR Name}.azurecr.io/cosmosdb/order-processor:latest   # update as per your environment, example myacrname.azurecr.io/cosmosdb/order-processor:latest. Do NOT add https:// in ACR Name
@@ -25,5 +26,3 @@ spec:
             value: https://{Cosmos DB Account Name}.documents.azure.com:443/  # update as per your environment
           - name: CosmosDbConfig__LeaseEndpoint
             value: https://{Cosmos DB Account Name}.documents.azure.com:443/ # update as per your environment
-
- 

--- a/Bicep/scaler_deploy.yaml
+++ b/Bicep/scaler_deploy.yaml
@@ -13,11 +13,12 @@ spec:
   template:
     metadata:
       labels:
-        aadpodidbinding: "cosmosdb-order-processor-identity"
+        azure.workload.identity/use: "true"
         app: cosmosdb-scaler
     spec:
+      serviceAccountName: workload-identity-sa
       containers:
-        - image: {ACR Name}azurecr.io/cosmosdb/scaler:latest   # update as per your environment, example myacrname.azurecr.io/cosmosdb/scaler:latest. Do NOT add https:// in ACR Name
+        - image: {ACR Name}.azurecr.io/cosmosdb/scaler:latest   # update as per your environment, example myacrname.azurecr.io/cosmosdb/scaler:latest. Do NOT add https:// in ACR Name
           imagePullPolicy: Always
           name: cosmosdb-scaler
           ports:

--- a/Bicep/service_account.yaml
+++ b/Bicep/service_account.yaml
@@ -1,0 +1,16 @@
+# Create namespace for the service account and services
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: cosmosdb-order-processor
+
+---
+# Create service account for use with workload identity
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    azure.workload.identity/client-id: {Workload Identity Client ID}  # update as per your environment
+  name: workload-identity-sa
+  namespace: cosmosdb-order-processor

--- a/Bicep/setup.sh
+++ b/Bicep/setup.sh
@@ -1,0 +1,63 @@
+# Deploy Azure Environment
+deploymentName=CosmosAksKedaDemo
+location=eastus
+az deployment sub create --name $deploymentName --location $location --template-file main.bicep --parameters @param.json
+
+# Setup KEDA  and external scaler
+aksName=$(az deployment sub show --name $deploymentName --query 'properties.outputs.aksName.value' -o tsv)
+rgName=$(az deployment sub show --name $deploymentName --query 'properties.outputs.resourceGroup.value' -o tsv)
+acrName=$(az deployment sub show --name $deploymentName --query 'properties.outputs.acrName.value' -o tsv)
+cosmosName=$(az deployment sub show --name $deploymentName --query 'properties.outputs.cosmosName.value' -o tsv)
+clientId=$(az deployment sub show --name $deploymentName --query 'properties.outputs.workloadIdentity.value' -o tsv)
+az aks get-credentials -n $aksName -g $rgName --admin --overwrite-existing
+
+helm repo add kedacore https://kedacore.github.io/charts
+helm repo update
+helm install keda kedacore/keda --namespace keda --create-namespace
+helm install external-scaler-azure-cosmos-db kedacore/external-scaler-azure-cosmos-db --namespace keda --create-namespace
+
+# Build and Deploy Scalar Container Image
+pushd ..
+az acr build --registry $acrName -f ./src/Scaler/Dockerfile -t cosmosdb/scaler:latest ./src
+popd
+
+# Create the service account for AKS Workload Identity
+sed -i "s/{Workload Identity Client ID}/${clientId}/g" ./service_account.yaml
+kubectl apply -f service_account.yaml
+
+# Deploy the scaler to AKS
+sed -i "s/{ACR Name}/${acrName}/g" ./scaler_deploy.yaml
+kubectl apply -f scaler_deploy.yaml
+
+# Build and Deploy the Order Processor
+pushd ..
+az acr build --registry $acrName -f ./src/Scaler.Demo/OrderProcessor/Dockerfile -t cosmosdb/order-processor:latest ./src
+popd
+
+sed -i "s/{ACR Name}/${acrName}/g" ./orderprocessor_deploy.yaml
+sed -i "s/{Cosmos DB Account Name}/${cosmosName}/g" ./orderprocessor_deploy.yaml
+kubectl apply -f orderprocessor_deploy.yaml
+
+# Deploy scaledobject to configure KEDA
+sed -i "s/{Cosmos DB Account Name}/${cosmosName}/g" ./deploy-scaledobject.yaml
+kubectl apply -f deploy-scaledobject.yaml
+
+# Build and Deploy the Single Partition Order Generator
+pushd ..
+az acr build --registry $acrName -f ./src/Scaler.Demo/OrderGenerator/Dockerfile -t cosmosdb/order-generator:latest ./src
+popd
+
+sed -i "s/{ACR Name}/${acrName}/g" ./ordergenerator_sp_deploy.yaml
+sed -i "s/{Cosmos DB Account Name}/${cosmosName}/g" ./ordergenerator_sp_deploy.yaml
+# kubectl apply -f ordergenerator_sp_deploy.yaml
+
+# Deploy the Multi Partition Order Generator
+sed -i "s/{ACR Name}/${acrName}/g" ./ordergenerator_mp_deploy.yaml
+sed -i "s/{Cosmos DB Account Name}/${cosmosName}/g" ./ordergenerator_mp_deploy.yaml
+# kubectl apply -f ordergenerator_mp_deploy.yaml
+
+kubectl get pods --namespace cosmosdb-order-processor
+
+echo "The AKS and Cosmos environment is ready."
+echo 'Deploy the single partition order generator with `kubectl apply -f ordergenerator_sp_deploy.yaml`'
+echo 'Deploy the multi partition order generator with `kubectl apply -f ordergenerator_mp_deploy.yaml`'

--- a/Demo Script
+++ b/Demo Script
@@ -17,7 +17,7 @@ kubectl get pods -n cosmosdb-order-processor --field-selector=status.phase=Runni
 kubectl logs <podname> -n cosmosdb-order-processor
 
 ## Switch to Grafana
-- SHow the generator deployment pod count going up 
-- How the no. of processor pods should match up to the     Count of Partitions with lag in the scaler logs.
+- Show the generator deployment pod count going up 
+- How the no. of processor pods should match up to the Count of Partitions with lag in the scaler logs.
 
 ## Move over to cosmosDB to show some of the insights and the cool partitioning Stuff

--- a/src/Scaler.Demo/OrderGenerator/appsettings.json
+++ b/src/Scaler.Demo/OrderGenerator/appsettings.json
@@ -4,6 +4,5 @@
     "DatabaseId": "StoreDatabase",
     "ContainerId": "OrderContainer",
     "ContainerThroughput": 11000,
-    "Connection": "AccountEndpoint=https:/{Cosmos Account Name}.documents.azure.com:443/;AccountKey={Secure Primary Key};"
   }
 }


### PR DESCRIPTION
## Purpose

Fixed the ACR Pull issue - was able to remove several steps from the demo setup how-to Added some outputs to the Bicep template to simplify data retrieval and command execution in the how-to section 

Removed the "ConnectionString" setting in appsettings.json for the OrderGenerator.  It was a placeholder which was overridden locally by environment variable, but when running in k8s caused an auth failure.  If the connection string is present, it doesn't try to use RBAC auth from the Pod or Workload Identity. 

Added an option in the how-to to use ACR Build tasks to build the container images (for those without Docker locally). 

Updated the README.md

## Does this introduce a breaking change?

```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

*  Get the code
*  Edit `./Bicep/setup.sh` to set a deployment name and location 
*  from the shell:
  *  `az login`
  *  `az account set --subscription {YOUR SUBSCRIPTION NAME or ID}`
  *  `cd ./Bicep`
  *  `./setup.sh`
* Deploy the order generators and run the demo as desired. 
